### PR TITLE
Fix cuda11.2

### DIFF
--- a/config/conda_build_config.yaml
+++ b/config/conda_build_config.yaml
@@ -1,0 +1,5 @@
+cxx_compiler_version:
+  - 11.*                      # [cudatoolkit == '11.2']
+cxx_compiler_version:
+  - 11.*                      # [cudatoolkit == '11.2']
+

--- a/config/conda_build_config.yaml
+++ b/config/conda_build_config.yaml
@@ -1,5 +1,5 @@
 cxx_compiler_version:
-  - 11.*                      # [cudatoolkit == '11.2']
+  - 11.*
 cxx_compiler_version:
-  - 11.*                      # [cudatoolkit == '11.2']
+  - 11.*
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Mamba 0.27.0 no more compiles with GCC less than 11. So, even for cuda 11.2, we need to build it using Anaconda's GCC 11. I checked the whole open-ce conda environment after having build mamba with GCC 11 and rest of the packages with GCC 7/8, and it worked fine.


## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
