### PR TITLE
Fixed mamba seg fault on FIPS enabled system

### DIFF
--- a/recipe/0001-Fix-for-mamba-seg-fault.patch
+++ b/recipe/0001-Fix-for-mamba-seg-fault.patch
@@ -1,0 +1,44 @@
+From 0b80f87f565abbfdc765569cd045ab49601b8115 Mon Sep 17 00:00:00 2001
+From: Nishidha Panpaliya <npanpa23@in.ibm.com>
+Date: Tue, 4 Apr 2023 22:47:15 -0700
+Subject: [PATCH] Fix for mamba seg fault
+
+---
+ libmamba/src/core/url.cpp | 18 +++++++++++-------
+ 1 file changed, 11 insertions(+), 7 deletions(-)
+
+diff --git a/libmamba/src/core/url.cpp b/libmamba/src/core/url.cpp
+index 8c1ad222..81c15cdd 100644
+--- a/libmamba/src/core/url.cpp
++++ b/libmamba/src/core/url.cpp
+@@ -161,16 +161,20 @@ namespace mamba
+             u = u.substr(0, u.size() - 13);
+         }
+ 
+-        unsigned char hash[16];
+-
+-        EVP_MD_CTX* mdctx;
+-        mdctx = EVP_MD_CTX_create();
+-        EVP_DigestInit_ex(mdctx, EVP_md5(), nullptr);
++        const EVP_MD* type = EVP_md5();
++        unsigned char hash[EVP_MAX_MD_SIZE];
++        if (FIPS_mode() || FIPS_mode_set(1))
++        {
++            type = EVP_sha256();
++        }
++        unsigned int mdLen = 0;
++        EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
++        EVP_DigestInit_ex(mdctx, type, nullptr);
+         EVP_DigestUpdate(mdctx, u.c_str(), u.size());
+-        EVP_DigestFinal_ex(mdctx, hash, nullptr);
++        EVP_DigestFinal_ex(mdctx, hash, &mdLen);
+         EVP_MD_CTX_destroy(mdctx);
+ 
+-        std::string hex_digest = hex_string(hash, 16);
++        std::string hex_digest = hex_string(hash, mdLen);
+         return hex_digest.substr(0u, 8u);
+     }
+ 
+-- 
+2.31.1
+

--- a/recipe/0001-Fix-for-mamba-seg-fault.patch
+++ b/recipe/0001-Fix-for-mamba-seg-fault.patch
@@ -22,7 +22,7 @@ index 8c1ad222..81c15cdd 100644
 -        EVP_DigestInit_ex(mdctx, EVP_md5(), nullptr);
 +        const EVP_MD* type = EVP_md5();
 +        unsigned char hash[EVP_MAX_MD_SIZE];
-+        if (FIPS_mode() || FIPS_mode_set(1))
++        if (FIPS_mode())
 +        {
 +            type = EVP_sha256();
 +        }

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ package:
 source:
   git_url: https://github.com/mamba-org/mamba
   git_rev: mamba-{{ mamba_version }}
+  patches:
+    - 0001-Fix-for-mamba-seg-fault.patch
 
 build:
   number: 1


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description
Fixed a segmentation fault error when mamba in presence of FIPS enabled openssl is run on a FIPS enabled system.

**Issue:** When FIPS enabled openssl and mamba (FIPS/non-FIPS) are installed in a conda environment, running `mamba create -n test python=3.9` or `mamba install <any_package>`, would result into segmentation fault on a FIPS enabled system. This error was not seen on non-FIPS system.

**Cause:** The seg fault is coming from std::string cache_name_from_url(const std::string& url) method of mamba source code where md5 code is used as below -
```      EVP_MD_CTX* mdctx;
        mdctx = EVP_MD_CTX_create();
        EVP_DigestInit_ex(mdctx, EVP_md5(), nullptr);
        EVP_DigestUpdate(mdctx, u.c_str(), u.size());
        EVP_DigestFinal_ex(mdctx, hash, nullptr);
        EVP_MD_CTX_destroy(mdctx);

        std::string hex_digest = hex_string(hash, 16);
        return hex_digest.substr(0u, 8u);
```
And we know that MD5 will fail on a FIPS enabled system with FIPS openssl. 
**Solution:**
Use sha256 hashing algorithm when FIPS mode is found to be ON, else use MD5.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
