### PR TITLE
[1.9.4] Using Anaconda openssl, so disable FIPS patch

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,11 +10,11 @@ source:
   git_url: https://github.com/mamba-org/mamba
   git_rev: mamba-{{ mamba_version }}
   # disabling fips for s390x because s390x does not support FIPS.
-  patches:                                     #[not s390x]
-    - 0001-Fix-for-mamba-seg-fault.patch       #[not s390x]
+#  patches:                                     #[not s390x]
+#    - 0001-Fix-for-mamba-seg-fault.patch       #[not s390x]
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: libmamba


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Disabled FIPs patch for now for build with openssl 3 from Anaconda. (not removed it currently, because later FIPS support is to be added)

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
